### PR TITLE
fix multiPV mated-in scores

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -18,6 +18,7 @@
 
 #include "misc.h"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cassert>

--- a/src/misc.h
+++ b/src/misc.h
@@ -19,7 +19,6 @@
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <chrono>
@@ -475,19 +474,6 @@ struct CommandLine {
     int    argc;
     char** argv;
 };
-
-namespace Utility {
-
-template<typename T, typename Predicate>
-void move_to_front(std::vector<T>& vec, Predicate pred) {
-    auto it = std::find_if(vec.begin(), vec.end(), pred);
-
-    if (it != vec.end())
-    {
-        std::rotate(vec.begin(), it, it + 1);
-    }
-}
-}
 
 #if defined(__GNUC__)
     #define sf_always_inline __attribute__((always_inline))

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -378,10 +378,13 @@ Thread* ThreadPool::get_best_thread() const {
         const bool bestThreadInProvenWin = is_win(bestThreadScore);
         const bool newThreadInProvenWin  = is_win(newThreadScore);
 
-        const bool bestThreadInProvenLoss =
-          bestThreadScore != -VALUE_INFINITE && is_loss(bestThreadScore);
+        const bool bestThreadInProvenLoss = bestThreadScore != -VALUE_INFINITE
+                                         && is_loss(bestThreadScore)
+                                         && !bestThread->worker->rootMoves[0].scoreLowerbound
+                                         && !bestThread->worker->rootMoves[0].scoreUpperbound;
         const bool newThreadInProvenLoss =
-          newThreadScore != -VALUE_INFINITE && is_loss(newThreadScore);
+          newThreadScore != -VALUE_INFINITE && is_loss(newThreadScore)
+          && !th->worker->rootMoves[0].scoreLowerbound && !th->worker->rootMoves[0].scoreUpperbound;
 
         // We make sure not to pick a thread with truncated principal variation
         const bool betterVotingValue =


### PR DESCRIPTION
In order to prevent unproven mated-in scores for the bestmove's PV line, master checks if an aborted search leads to such a `uciScore`. If it is equal to `score` (and so no bound), master suppresses the UCI output of the PV and later replaces bestmove with the one from the last completed iteration. Score and PV, however, are taken from the iteration that last changed bestmove.

Unfortunately, the current logic has some flaws when it comes to multiPV analysis and outputting a ponder move, see #6642. Fixing these with the current approach would be quite involved.

Instead this patch takes a much simpler approach. Rather than suppressing the PV's output, we mark its score as an `upperbound`, indicating to the user that this mated-in score resulted from an aborted search.

This does not affect matetrack performance, for example, since matetrack only counts the final exact mate announcements for each search.

As a side-effect, we no longer need to insist on completing a depth 1 search.

In terms of game play, with 1 thread master would play the bestmove from the last completed iteration. The patch would play the bestmove from the aborted search and flag the mated-in score as an `upperbound`. In multi-threaded games with master the thread would offer the bestmove and search depth from the last completed iteration for best thread selection, together with the move's score from the iteration that last changed bestmove. The patch would offer the current bestmove, with the  `upperbound` score from the current iteration. This score will not be treated as a known loss in the best thread selection.

Fixes #6642.

No functional change